### PR TITLE
build: Add PEP 517/518 build-system metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
                            'runSModelS.py=smodels.tools.runSModelS:main',
                            'smodelsTools.py=smodels.tools.smodelsTools:main' ]
     },
+    python_requires='>=3.7',
     install_requires=requirements(),
     data_files=dataFiles() ,
     description=("A tool for interpreting simplified-model results from the "


### PR DESCRIPTION
* Add pyproject.toml with build-system table for setuptools as the build backend.
   - c.f. https://learn.scientific-python.org/development/guides/packaging-classic/
* Add python_requires lower bound.
   - Python 3.7 is already effectively enforced by the pyhf requirement, but this metadata is crucial for installers to not get incorrect versions that are broken at install.