### PR TITLE
build: Remove uneeded buid requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=61.0","pip"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
* The build requirements are the necessary build tooling. pip is an installer front end and not a build system.